### PR TITLE
Instantiate a custom amount of objects on startup to save even more performance

### DIFF
--- a/Assets/ObjectPool/Demo/Scripts/Turret.cs
+++ b/Assets/ObjectPool/Demo/Scripts/Turret.cs
@@ -8,8 +8,8 @@ public class Turret : MonoBehaviour
 
 	void Start()
 	{
-		bulletPrefab.CreatePool();
-		bulletPrefab.explosionPrefab.CreatePool();
+		bulletPrefab.CreatePool(10);
+		bulletPrefab.explosionPrefab.CreatePool(10);
 	}
 
 	void Update()

--- a/Assets/ObjectPool/Scripts/ObjectPool.cs
+++ b/Assets/ObjectPool/Scripts/ObjectPool.cs
@@ -96,6 +96,22 @@ public sealed class ObjectPool : MonoBehaviour
 			Recycle(active[i]);
 	}
 
+	public static List<T> GetAllOfType<T>() where T : Component
+	{
+		var keys = instance.objectLookup.Keys.Where(p => p.GetType() == typeof(T)).ToList();
+
+		List<T> objects = new List<T>();
+
+		if(keys.Count > 0)			
+			foreach(var key in keys)
+				if(instance.objectLookup[key].Count > 0)
+					foreach(var obj in instance.objectLookup[key]) 
+						objects.Add(obj as T);
+
+
+		return objects;
+	}
+
 	public static int Count<T>(T prefab) where T : Component
 	{
 		if (instance.objectLookup.ContainsKey(prefab))
@@ -151,6 +167,11 @@ public static class ObjectPoolExtensions
 	public static void RecycleAll<T>(this T obj) where T : Component
 	{
 		ObjectPool.RecycleAll(obj);
+	}
+
+	public static List<T> GetAllOfType<T>(this T prefab) where T : Component
+	{
+		return ObjectPool.GetAllOfType<T>();
 	}
 
 	public static int Count<T>(T prefab) where T : Component


### PR DESCRIPTION
With the actual code, if you have a fire rate that allows you to shoot let's say 100 bullets at a time, it will instantiate 100 game objects at runtime for the first shoots. Now if you have different pools running at once like bullets, explosions, coins, power ups, etc (like I have in my game, 7 pools) think about instantiating all these objects when the game is running the first time we need the objects, there is a noticeable frame rate and performance drop during the gameplay, specially in fast paced games.

For that reason I improved the class to allow the pre-instantiation of a defined amount of objects at startup. For the Turrent demo, on startup 10 bullets and 10 explosions are added to the pool and recycled before we even need them, this way when we shoot, the pool will never create another object, since 10 is more than enough to the demo's fire rate.

The magic is in the new CreatePool<T>(T prefab, int initialAmount) and RecycleAll<T>(T obj) methods.

EDITED: CreatePool<T>(T prefab, int initialAmount) now uses SpawnInactive instead of Spawn + RecycleAll.
